### PR TITLE
Update component documentation links

### DIFF
--- a/chapters/chapter-03/readme.md
+++ b/chapters/chapter-03/readme.md
@@ -8,7 +8,7 @@ In this chapter we explore the NR1 API component documentation and use some of t
 
 NR1 comes with a number of really great components that we can use out of the box to allow us to build our application UI. We'll go into more detail of what a component is (and build our own) later, but for now lets look at whats available.
 
-Navigate to the [component documentation](https://developer.newrelic.com/client-side-sdk/index.html) area of the New Relic developer website. In the left hand navigation panel you should see a "UI Components" section. Find and select the **HeadingText** component. You will see that the documentation shows you how to import the component and then explains all the properties ("Props") you can specify for the component. 
+Navigate to the [component documentation](https://developer.newrelic.com/explore-docs/intro-to-sdk) area of the New Relic developer website. In the left hand navigation panel you should see a "UI Components" section. Find and select the **HeadingText** component. You will see that the documentation shows you how to import the component and then explains all the properties ("Props") you can specify for the component. 
 
 
 

--- a/chapters/chapter-04/readme.md
+++ b/chapters/chapter-04/readme.md
@@ -94,7 +94,7 @@ You can style elements with classes and inline styles, as well as use components
 
 ### 2a. Styling the header
 
-Lets improve our header style. First we will change the heading to use a [HeadingText](https://developer.newrelic.com/client-side-sdk/index.html#components/HeadingText) component.  Open the `/nerdlets/zerotohero-nerdlet/index.js` file and change the heading text to use the component like this:
+Lets improve our header style. First we will change the heading to use a [HeadingText](https://developer.newrelic.com/components/heading-text) component.  Open the `/nerdlets/zerotohero-nerdlet/index.js` file and change the heading text to use the component like this:
 
 ```jsx
 <GridItem columnSpan={11}>

--- a/chapters/chapter-05/readme.md
+++ b/chapters/chapter-05/readme.md
@@ -28,7 +28,7 @@ First we need to adjust our layout to be three columns instead of two. Open up t
 
 ### 1b. Adding the Pie Chart
 
-Take a look at the [documentation of the PieChart component](https://developer.newrelic.com/client-side-sdk/index.html#charts/PieChart). We'll use the Basic version for now where we supply a query and account ID/ Later we'll look at how to render charts from data. 
+Take a look at the [documentation of the PieChart component](https://developer.newrelic.com/components/pie-chart). We'll use the Basic version for now where we supply a query and account ID/ Later we'll look at how to render charts from data. 
 
 First import the PieChart component at the top of `index.js` :
 
@@ -72,9 +72,9 @@ In some cases (especially if you see 403 errors in the inspector) it might be ne
 
 ### 1c. Adding the Line Chart and Billboard
 
-Add the [LineChart component](https://developer.newrelic.com/client-side-sdk/index.html#charts/LineChart) in the same way as the PieChart was added. It needs an account Id and query. Simply add the keyword timeseries to the query to make it render as a graph over time.
+Add the [LineChart component](https://developer.newrelic.com/components/line-chart) in the same way as the PieChart was added. It needs an account Id and query. Simply add the keyword timeseries to the query to make it render as a graph over time.
 
-Also add the [Billboard component](https://developer.newrelic.com/client-side-sdk/index.html#charts/BillboardChart) under the title in the first column. This query is the same as the one in the pie chart by with the `facet` clause removed.
+Also add the [Billboard component](https://developer.newrelic.com/components/billboard-chart) under the title in the first column. This query is the same as the one in the pie chart by with the `facet` clause removed.
 
 Finally add the attribute `fullHeight` and `fullWidth` to all three chart components to ensure they fill the entire height of the row.
 

--- a/chapters/chapter-06/readme.md
+++ b/chapters/chapter-06/readme.md
@@ -269,7 +269,7 @@ Also add the "AppIcon" class to the `<GridItem>` containing the icon (this just 
 
 This is looking a lot better now, but lets add some icons. The NR1 component library comes with a handy `<Icon>` component that we can use to quickly add icons to our application. 
 
-Find the documentation for the [icon component](https://developer.newrelic.com/client-side-sdk/index.html#components/Icon). In the Examples section click on "All Icons" . You will see all the icons rendered so you can easily choose what you need. You can click on an icon and its type is copied to clipboard. Very useful!
+Find the documentation for the [icon component](https://developer.newrelic.com/components/icon). In the Examples section click on "All Icons" . You will see all the icons rendered so you can easily choose what you need. You can click on an icon and its type is copied to clipboard. Very useful!
 
 ![All icons example](./screenshots/allicons.png)
 

--- a/chapters/chapter-07/readme.md
+++ b/chapters/chapter-07/readme.md
@@ -8,7 +8,7 @@ In this chapter we connect our charts to the time picker, and use it as an excus
 
 Oh my, what a name for a component!
 
-A quick look in the [docs](https://developer.newrelic.com/client-side-sdk/index.html#apis/PlatformStateContext) doesn't really tell us much either. Essentially this is the component that provides us data about the current context of the nerdlet, such as time frame selected. 
+A quick look in the [`PlatformStateContext` docs](https://developer.newrelic.com/components/platform-state-context) doesn't really tell us much either. Essentially this is the component that provides us data about the current context of the nerdlet, such as time frame selected. 
 
 
 

--- a/chapters/chapter-11/readme.md
+++ b/chapters/chapter-11/readme.md
@@ -20,7 +20,7 @@ We've already been using the `render()` method. We now need to load our data, th
 
 ## 2. Loading....
 
-Loading of data is asynchronous, we don't want the application to stall whilst the data is loaded. The convention is to provide some sort of feedback to the user that something will happen soon. The NR1 component library has a [`<Spinner>`](https://developer.newrelic.com/client-side-sdk/index.html#components/Spinner) component just for this purpose.
+Loading of data is asynchronous, we don't want the application to stall whilst the data is loaded. The convention is to provide some sort of feedback to the user that something will happen soon. The NR1 component library has a [`<Spinner>`](https://developer.newrelic.com/components/spinner) component just for this purpose.
 
 We will store the loaded data in **state** which we explored in [chapter 8](../chapter-08). Until there is data loaded we want to show a loading spinner. Lets do that now:
 
@@ -235,7 +235,7 @@ We will use this query (with some adjustments) in our application.
 
 ### 3c. Loading data with `NerdGraphQuery`
 
-We will retrieve data from New Relic using the [NerdGrpahQuery component](https://developer.newrelic.com/client-side-sdk/index.html#data-fetching/NerdGraphQuery) from the component library. This allows us to construct and send a [graphQL](https://graphql.org/) query to the API and receive a response back.
+We will retrieve data from New Relic using the [NerdGraphQuery component](https://developer.newrelic.com/components/nerd-graph-query) from the component library. This allows us to construct and send a [graphQL](https://graphql.org/) query to the API and receive a response back.
 
 
 

--- a/chapters/chapter-12/readme.md
+++ b/chapters/chapter-12/readme.md
@@ -53,7 +53,7 @@ Lets add a custom control that allows the user indicate that only slow transacti
 
 ### 2a. Adding the control
 
-We can use a checkbox for this simple control. The [`<Checkbox>`](https://developer.newrelic.com/client-side-sdk/index.html#components/Checkbox) component from the NR1 component library will do nicely.
+We can use a checkbox for this simple control. The [`<Checkbox>`](https://developer.newrelic.com/components/checkbox) component from the NR1 component library will do nicely.
 
 In the main nerdlet `index.js` file change the frist `<Grid>` into three columns by adding a new `<GridItem>` and setting the columnSpan's to 1, 8 and 3.
 

--- a/chapters/chapter-13/readme.md
+++ b/chapters/chapter-13/readme.md
@@ -167,7 +167,7 @@ We can see the data is returned in two parts`data.actor.account.browser` and `da
 
 
 
-The [example in the documentation](https://developer.newrelic.com/client-side-sdk/index.html#charts/LineChart) shows how custom data should be passed to the `<LineChart>` component. The data attribute is an array of objects, each object is a point on the chart specified as x (time data) and y (transactions) data. There is also meta data describing how the series of data should be formatted.
+The [example in the documentation](https://developer.newrelic.com/components/line-chart) shows how custom data should be passed to the `<LineChart>` component. The data attribute is an array of objects, each object is a point on the chart specified as x (time data) and y (transactions) data. There is also meta data describing how the series of data should be formatted.
 
 ![Example custom data](./screenshots/examplecustomdata.png)
 
@@ -222,7 +222,7 @@ Hopefully your application should be rendering something like this:
 
 **Alternative data loading method:**
 
-Theres more than one way to skin a cat. The above method uses graphql to query the data and then we learn to format it for the chart. However there are some components that make this a little simpler. Explore the [`<NrqlQuery>`](https://developer.newrelic.com/client-side-sdk/index.html#data-fetching/NrqlQuery) component in the compnent library for a simpler method for single queries. This is also used in the [workshop lab 7](https://github.com/newrelic/nr1-workshop/blob/master/lab7/INSTRUCTIONS.md)
+Theres more than one way to skin a cat. The above method uses graphql to query the data and then we learn to format it for the chart. However there are some components that make this a little simpler. Explore the [`<NrqlQuery>`](https://developer.newrelic.com/components/nrql-query) component in the compnent library for a simpler method for single queries. This is also used in the [workshop lab 7](https://github.com/newrelic/nr1-workshop/blob/master/lab7/INSTRUCTIONS.md)
 
 
 


### PR DESCRIPTION
It looks like some links weren't updated along with changes to the organization of the docs. As a result, those links end up leading to the root of the docs rather than the specific component that they're meant to reference. This PR updates the links that use what appears to be an older URL.